### PR TITLE
chore: relax mention space guard when maxWords is null

### DIFF
--- a/lib/src/mention_tag_text_editing_controller.dart
+++ b/lib/src/mention_tag_text_editing_controller.dart
@@ -246,8 +246,15 @@ class MentionTagTextEditingController extends TextEditingController {
           indexCursor,
         );
 
-        // Check if mentionCandidate contains a space
-        if (mentionCandidate.contains(' ')) {
+        // Check if mentionCandidate contains a space.
+        //
+        // When [maxWords] is null the field places no word limit on a mention,
+        // so a multi-word candidate (e.g. a display name like "Derek Ross")
+        // must keep flowing through to [onMention] — otherwise the search
+        // overlay is killed the instant the user types a space. Only bail on a
+        // space when a word limit is actually set.
+        if (mentionTagDecoration.maxWords != null &&
+            mentionCandidate.contains(' ')) {
           return null;
         }
 

--- a/test/mention_tag_text_field_test.dart
+++ b/test/mention_tag_text_field_test.dart
@@ -162,6 +162,55 @@ void main() {
       },
     );
 
+    testWidgets(
+      'with maxWords null, a multi-word candidate keeps flowing to onMention '
+      'after a space (so the search overlay stays open for spaced names)',
+      (tester) async {
+        String? lastMention;
+        controller
+          ..mentionTagDecoration = const MentionTagDecoration(maxWords: null)
+          ..onMention = (m) => lastMention = m;
+
+        await tester.pumpWidget(const MaterialApp(home: SizedBox.shrink()));
+
+        // Type "@Derek Ross" with the caret at the end; a space mid-candidate
+        // must NOT null out the mention when no word limit is set.
+        controller
+          ..text = '@Derek Ross'
+          ..selection = const TextSelection.collapsed(offset: 11);
+        controller.onChanged('@Derek Ross');
+
+        expect(
+          lastMention,
+          '@Derek Ross',
+          reason: 'maxWords == null must allow spaced multi-word candidates',
+        );
+      },
+    );
+
+    testWidgets(
+      'with maxWords set, a space still ends the candidate (unchanged behavior)',
+      (tester) async {
+        String? lastMention;
+        controller
+          ..mentionTagDecoration = const MentionTagDecoration(maxWords: 1)
+          ..onMention = (m) => lastMention = m;
+
+        await tester.pumpWidget(const MaterialApp(home: SizedBox.shrink()));
+
+        controller
+          ..text = '@Derek Ross'
+          ..selection = const TextSelection.collapsed(offset: 11);
+        controller.onChanged('@Derek Ross');
+
+        expect(
+          lastMention,
+          isNull,
+          reason: 'a word limit must still bail on a space',
+        );
+      },
+    );
+
     test(
       'the selection listener ignores non-collapsed (range) selections '
       'while a mention is mid-edit',


### PR DESCRIPTION
## What

`_getMention` bailed on **any** space in the mention candidate, regardless of the `maxWords` setting:

```dart
if (mentionCandidate.contains(' ')) {
  return null;
}
```

This kills the search overlay the instant a user types a space inside a mention. For consumers that set **`maxWords: null`** (no word limit — e.g. tagging a user whose display name contains a space like `@Derek Ross`), the overlay should keep firing across the space so the suggestion stays tappable.

## Change

Only bail on a space when a word limit is actually set:

```dart
if (mentionTagDecoration.maxWords != null &&
    mentionCandidate.contains(' ')) {
  return null;
}
```

- `maxWords == null` → multi-word candidate flows through to `onMention` (overlay stays open).
- `maxWords` set (incl. the default `1`) → **unchanged**; a space still ends the candidate.

The earlier `maxWords != null` end-of-candidate guard (the `indexOfNthSpace` block) already short-circuits the limited case before this point, so the two guards stay consistent.

## Blast radius

Low. The only behavior change is on the `maxWords == null` path; every `maxWords`-set caller is byte-for-byte identical.

## Tests

Added two cases:
- `maxWords: null` + spaced candidate → `onMention` receives the full `@Derek Ross`.
- `maxWords: 1` + spaced candidate → `onMention` receives `null` (regression lock).

All existing tests pass.

## Upstream status

Patch lives on the `MaTeS72` fork. Not yet offered to `iWOLFSTEIN` upstream — open to forwarding if useful there.